### PR TITLE
Remove cuda_backend default features

### DIFF
--- a/wrappers/rust/icicle-curves/icicle-bn254/Cargo.toml
+++ b/wrappers/rust/icicle-curves/icicle-bn254/Cargo.toml
@@ -20,7 +20,7 @@ serial_test = "3.0.0"
 cmake = "0.1.50"
 
 [features]
-default = ["cuda_backend"]
+default = []
 no_g2 = []
 no_ecntt = []
 cuda_backend = ["icicle-runtime/cuda_backend"]

--- a/wrappers/rust/icicle-runtime/Cargo.toml
+++ b/wrappers/rust/icicle-runtime/Cargo.toml
@@ -18,7 +18,7 @@ cmake = "0.1.50"
 # Enabling backend features means building them with the ICICLE frontend.
 # Sources must be either local (under icicle/backend) or pulled during the build process.
 # Note: Backend repositories are private and not meant for user workflows. Users should install backends directly instead.
-default = ["cuda_backend"]
+default = []
 cuda_backend = []
 pull_cuda_backend = []
 metal_backend = []


### PR DESCRIPTION
## Describe the changes

This PR removes cuda_backend as default features in rust cuda-runtime and bn254 Cargo.toml

## Linked Issues

Resolves #
